### PR TITLE
Fix dtype parameter name in transformers backend

### DIFF
--- a/soprano/backends/transformers.py
+++ b/soprano/backends/transformers.py
@@ -16,7 +16,7 @@ class TransformersModel(BaseModel):
         
         self.model = AutoModelForCausalLM.from_pretrained(
             model_name_or_path,
-            dtype=torch.bfloat16 if device == 'cuda' else torch.float32,
+            torch_dtype=torch.bfloat16 if device == 'cuda' else torch.float32,
             device_map=device
         )
         self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)


### PR DESCRIPTION
## Summary
- Fix `dtype=` → `torch_dtype=` in `AutoModelForCausalLM.from_pretrained()`

## Problem
The transformers backend crashes on startup with:
```
TypeError: Object of type dtype is not JSON serializable
```

This happens because `dtype` is not a valid parameter for `from_pretrained()`. The torch dtype object gets passed through to the model config, and when transformers tries to serialize the config to JSON for logging, it fails.

## Who is affected
- Users running on CPU (where transformers backend is forced by auto-selection)
- Anyone explicitly selecting `backend='transformers'`

## Fix
Single character change: `dtype=` → `torch_dtype=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)