### PR TITLE
Add WebUI host and port options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Start WebUI:
 ```bash
 soprano-webui # hosted on http://127.0.0.1:7860 by default
 ```
+> **Tip:** Use `--host` and `--port` to change the bind address, for example:
+> ```bash
+> soprano-webui --host 0.0.0.0 --port 8080
+> ```
 > **Tip:** You can increase cache size and decoder batch size to increase inference speed at the cost of higher memory usage. For example:
 > ```bash
 > soprano-webui --cache-size 1000 --decoder-batch-size 4

--- a/soprano/webui.py
+++ b/soprano/webui.py
@@ -25,6 +25,10 @@ parser.add_argument('--cache-size', '-c', type=int, default=100,
                     help='Cache size in MB (for lmdeploy backend)')
 parser.add_argument('--decoder-batch-size', '-bs', type=int, default=1,
                     help='Batch size when decoding audio')
+parser.add_argument('--host', default='127.0.0.1',
+                    help='Host/IP to bind the WebUI server (default: 127.0.0.1)')
+parser.add_argument('--port', type=int, default=None,
+                    help='Port to bind the WebUI server (default: auto-select)')
 args = parser.parse_args()
 
 # Initialize model
@@ -219,10 +223,10 @@ def find_free_port(start_port=7860, max_tries=100):
 
 def main():
     # Start Gradio interface
-    port = find_free_port(7860)
+    port = args.port if args.port is not None else find_free_port(7860)
     print(f"Starting Gradio interface on port {port}")
     demo.launch(
-        server_name="127.0.0.1",
+        server_name=args.host,
         server_port=port,
         share=False,
         theme=gr.themes.Soft(primary_hue="green"),


### PR DESCRIPTION
**Motivation**

Provide a simple way to control the WebUI bind address and port so users can change the listen IP and/or use a fixed port instead of the auto-selected port.

**Description**

Add CLI arguments --host (default 127.0.0.1) and --port (default None) to soprano/webui.py and wire them into demo.launch, using find_free_port when --port is not specified.
Update README.md to document usage examples for --host and --port when starting the WebUI.

**Testing**

No automated tests were run for this change.
