### PR TITLE
Feature: Add ONNX export pipeline and refactor CLI into subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ BACKEND-SELECTION.md
 Taskfile.yml
 benchmark.py
 examples-backend.py
+onnx_models/
+uv.lock
+.idea
+.DS_Store
+CLAUDE.md
+test_output/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,13 @@ dependencies = [
   "transformers>=4.51.0",
   "unidecode",
   "uvicorn",
-  "inflect"
+  "inflect",
 ]
 license = {file = "LICENSE"}
 
 [project.optional-dependencies]
 lmdeploy = ["lmdeploy"]
+onnx = ["onnxruntime>=1.24.3", "onnx>=1.20.1", "onnxscript>=0.6.2"]
 
 [project.urls]
 Homepage = "https://github.com/ekwek1/soprano"
@@ -41,3 +42,6 @@ Issues = "https://github.com/ekwek1/soprano/issues"
 [project.scripts]
 soprano = "soprano.cli:main"
 soprano-webui = "soprano.webui:main"
+
+[tool.setuptools.packages.find]
+include = ["soprano*"]

--- a/soprano/_constants.py
+++ b/soprano/_constants.py
@@ -1,0 +1,1 @@
+MODEL_ID = 'ekwek/Soprano-1.1-80M'

--- a/soprano/backends/lmdeploy.py
+++ b/soprano/backends/lmdeploy.py
@@ -1,6 +1,7 @@
 import torch
 from lmdeploy import pipeline, TurbomindEngineConfig, GenerationConfig
 from .base import BaseModel
+from soprano._constants import MODEL_ID
 
 
 class LMDeployModel(BaseModel):
@@ -14,7 +15,7 @@ class LMDeployModel(BaseModel):
         backend_config = TurbomindEngineConfig(cache_max_entry_count=cache_size_ratio)
         
         # Use local model if path provided, otherwise use HuggingFace
-        model_name_or_path = model_path if model_path else 'ekwek/Soprano-1.1-80M'
+        model_name_or_path = model_path if model_path else MODEL_ID
         
         self.pipeline = pipeline(model_name_or_path,
             log_level='ERROR',

--- a/soprano/backends/transformers.py
+++ b/soprano/backends/transformers.py
@@ -2,6 +2,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers import LogitsProcessorList, RepetitionPenaltyLogitsProcessor, TemperatureLogitsWarper, TopPLogitsWarper
 from .base import BaseModel
+from soprano._constants import MODEL_ID
 
 
 class TransformersModel(BaseModel):
@@ -12,7 +13,7 @@ class TransformersModel(BaseModel):
         self.device = device
         
         # Use local model if path provided, otherwise use HuggingFace
-        model_name_or_path = model_path if model_path else 'ekwek/Soprano-1.1-80M'
+        model_name_or_path = model_path if model_path else MODEL_ID
         
         self.model = AutoModelForCausalLM.from_pretrained(
             model_name_or_path,

--- a/soprano/cli.py
+++ b/soprano/cli.py
@@ -1,42 +1,24 @@
 #!/usr/bin/env python3
-"""
-Soprano TTS Command Line Interface
-"""
+"""Soprano TTS Command Line Interface"""
+import sys
 import argparse
-from soprano import SopranoTTS
-from soprano.utils.streaming import play_stream
 
-def main():
-    parser = argparse.ArgumentParser(description='Soprano Text-to-Speech CLI')
-    parser.add_argument('text', help='Text to synthesize')
-    parser.add_argument('--output', '-o', default='output.wav',
-                        help='Output audio file path (non-streaming only)')
-    parser.add_argument('--model-path', '-m',
-                        help='Path to local model directory (optional)')
-    parser.add_argument('--device', '-d', default='auto',
-                        choices=['auto', 'cuda', 'cpu', 'mps'],
-                        help='Device to use for inference')
-    parser.add_argument('--backend', '-b', default='auto',
-                        choices=['auto', 'transformers', 'lmdeploy'],
-                        help='Backend to use for inference')
-    parser.add_argument('--cache-size', '-c', type=int, default=100,
-                        help='Cache size in MB (for lmdeploy backend)')
-    parser.add_argument('--decoder-batch-size', '-bs', type=int, default=1,
-                        help='Batch size when decoding audio')
-    parser.add_argument('--streaming', '-s', action='store_true',
-                        help='Enable streaming playback to speakers')
-    
-    args = parser.parse_args()
-    
-    # Initialize TTS
+from soprano._constants import MODEL_ID
+
+SUBCOMMANDS = {'tts', 'export', 'test-e2e'}
+
+
+def cmd_tts(args):
+    from soprano import SopranoTTS
+    from soprano.utils.streaming import play_stream
+
     tts = SopranoTTS(
         backend=args.backend,
         device=args.device,
         cache_size_mb=args.cache_size,
         decoder_batch_size=args.decoder_batch_size,
-        model_path=args.model_path
+        model_path=args.model_path,
     )
-    
     print(f"Generating speech for: '{args.text}'")
     if args.streaming:
         stream = tts.infer_stream(args.text, chunk_size=1)
@@ -44,6 +26,148 @@ def main():
     else:
         tts.infer(args.text, out_path=args.output)
         print(f"Audio saved to: {args.output}")
+
+
+def cmd_export(args):
+    try:
+        from soprano.onnx_export import export_all, export_backbone, export_decoder
+    except ImportError:
+        print("ONNX export requires extra dependencies. Install with:")
+        print("  uv pip install soprano-tts[onnx]")
+        sys.exit(1)
+
+    shared = dict(
+        output_dir=args.output_dir,
+        model_id=args.model_id,
+        validate=args.validate,
+        convert_f16=args.f16,
+        keep_f32=args.keep_f32,
+    )
+    if args.component == 'all':
+        result = export_all(
+            **shared,
+            run_e2e=args.e2e,
+            e2e_sentences=args.e2e_sentences,
+            e2e_compare_baseline=args.compare_baseline,
+            e2e_snr_pass_threshold=args.snr_threshold,
+        )
+    elif args.component == 'backbone':
+        result = export_backbone(**shared)
+    elif args.component == 'decoder':
+        result = export_decoder(**shared)
+    else:
+        raise ValueError(f"Unknown component: {args.component}")
+
+    paths = [v for k, v in result.items() if k.endswith('_path') and v]
+    if paths:
+        print(f"\nExported: {', '.join(paths)}")
+
+
+def cmd_test_e2e(args):
+    try:
+        from soprano.onnx_export import test_e2e
+    except ImportError:
+        print("ONNX e2e test requires extra dependencies. Install with:")
+        print("  uv pip install soprano-tts[onnx]")
+        sys.exit(1)
+
+    test_e2e(
+        onnx_dir=args.onnx_dir,
+        model_id=args.model_id,
+        test_sentences=args.sentences,
+        use_f16=not args.f32,
+        max_new_tokens=args.max_new_tokens,
+        compare_baseline=args.compare_baseline,
+        snr_pass_threshold=args.snr_threshold,
+        snr_marginal_threshold=args.snr_marginal_threshold,
+        save_audio=args.save_audio,
+    )
+
+
+def main():
+    # Backwards compat: if first arg isn't a subcommand, assume 'tts'.
+    # Note: text that exactly matches a subcommand name (e.g. "export") will be
+    # interpreted as that subcommand rather than TTS input.
+    argv = sys.argv[1:]
+    if argv and argv[0] not in SUBCOMMANDS and not argv[0].startswith('-'):
+        argv = ['tts'] + argv
+
+    parser = argparse.ArgumentParser(description='Soprano Text-to-Speech CLI')
+    subparsers = parser.add_subparsers(dest='command')
+
+    # --- tts ---
+    tts_parser = subparsers.add_parser('tts', help='Synthesize speech from text')
+    tts_parser.add_argument('text', help='Text to synthesize')
+    tts_parser.add_argument('--output', '-o', default='output.wav',
+                            help='Output audio file path (non-streaming only)')
+    tts_parser.add_argument('--model-path', '-m',
+                            help='Path to local model directory (optional)')
+    tts_parser.add_argument('--device', '-d', default='auto',
+                            choices=['auto', 'cuda', 'cpu', 'mps'],
+                            help='Device to use for inference')
+    tts_parser.add_argument('--backend', '-b', default='auto',
+                            choices=['auto', 'transformers', 'lmdeploy'],
+                            help='Backend to use for inference')
+    tts_parser.add_argument('--cache-size', '-c', type=int, default=100,
+                            help='Cache size in MB (for lmdeploy backend)')
+    tts_parser.add_argument('--decoder-batch-size', '-bs', type=int, default=1,
+                            help='Batch size when decoding audio')
+    tts_parser.add_argument('--streaming', '-s', action='store_true',
+                            help='Enable streaming playback to speakers')
+    tts_parser.set_defaults(func=cmd_tts)
+
+    # --- export ---
+    export_parser = subparsers.add_parser('export', help='Export models to ONNX')
+    export_parser.add_argument('--component', choices=['all', 'backbone', 'decoder'],
+                               default='all', help='Which component to export')
+    export_parser.add_argument('--output-dir', default='onnx_models',
+                               help='Directory to save ONNX models')
+    export_parser.add_argument('--model-id', default=MODEL_ID,
+                               help='HuggingFace model ID')
+    export_parser.add_argument('--no-validate', action='store_false', dest='validate',
+                               help='Skip validation against PyTorch baselines')
+    export_parser.add_argument('--no-f16', action='store_false', dest='f16',
+                               help='Skip float16 conversion')
+    export_parser.add_argument('--keep-f32', action='store_true',
+                               help='Keep f32 model after f16 conversion')
+    export_parser.add_argument('--no-e2e', action='store_false', dest='e2e',
+                               help='Skip end-to-end test after export (only for --component all)')
+    export_parser.add_argument('--e2e-sentences', nargs='+',
+                               help='Custom test sentences for e2e test')
+    export_parser.add_argument('--no-compare-baseline', action='store_false', dest='compare_baseline',
+                               help='Skip PyTorch baseline comparison in e2e test')
+    export_parser.add_argument('--snr-threshold', type=float, default=30.0,
+                               help='Min SNR (dB) for e2e test PASS')
+    export_parser.set_defaults(func=cmd_export)
+
+    # --- test-e2e ---
+    e2e_parser = subparsers.add_parser('test-e2e', help='Run ONNX end-to-end inference test')
+    e2e_parser.add_argument('--onnx-dir', default='onnx_models',
+                            help='Directory containing exported ONNX models')
+    e2e_parser.add_argument('--model-id', default=MODEL_ID,
+                            help='HuggingFace model ID')
+    e2e_parser.add_argument('--sentences', nargs='+',
+                            help='Custom test sentences')
+    e2e_parser.add_argument('--f32', action='store_true',
+                            help='Use f32 ONNX models instead of f16')
+    e2e_parser.add_argument('--max-new-tokens', type=int, default=512,
+                            help='Max tokens for autoregressive generation')
+    e2e_parser.add_argument('--no-compare-baseline', action='store_false', dest='compare_baseline',
+                            help='Skip PyTorch baseline comparison')
+    e2e_parser.add_argument('--snr-threshold', type=float, default=30.0,
+                            help='Min SNR (dB) for PASS status')
+    e2e_parser.add_argument('--snr-marginal-threshold', type=float, default=20.0,
+                            help='Min SNR (dB) for MARGINAL status')
+    e2e_parser.add_argument('--save-audio', metavar='DIR',
+                            help='Directory to save generated .wav files')
+    e2e_parser.set_defaults(func=cmd_test_e2e)
+
+    args = parser.parse_args(argv)
+    if not hasattr(args, 'func'):
+        parser.print_help()
+        sys.exit(1)
+    args.func(args)
+
 
 if __name__ == "__main__":
     main()

--- a/soprano/onnx_export/__init__.py
+++ b/soprano/onnx_export/__init__.py
@@ -1,0 +1,104 @@
+"""
+ONNX export API for Soprano TTS.
+
+Usage:
+    from soprano.onnx_export import export_all, export_backbone, export_decoder, test_e2e
+
+    # Export both backbone and decoder, then run e2e test
+    result = export_all()
+
+    # Export individually
+    result = export_backbone()
+    result = export_decoder()
+
+    # Export without validation (faster)
+    result = export_all(validate=False)
+
+    # Export + e2e test with custom sentences
+    result = export_all(e2e_sentences=["Hello world.", "Test sentence."])
+
+    # Run e2e test only (models already exported)
+    results = test_e2e()
+    results = test_e2e(compare_baseline=False)  # skip PyTorch comparison
+"""
+from soprano._constants import MODEL_ID
+from ._utils import DEFAULT_OUTPUT_DIR
+from .export_backbone import export_backbone
+from .export_decoder import export_decoder
+from .onnx_e2e_inference import test_e2e
+
+
+def export_all(
+    output_dir=DEFAULT_OUTPUT_DIR,
+    model_id=MODEL_ID,
+    validate=True,
+    convert_f16=True,
+    keep_f32=False,
+    backbone_kwargs=None,
+    decoder_kwargs=None,
+    run_e2e=True,
+    e2e_sentences=None,
+    e2e_compare_baseline=True,
+    e2e_snr_pass_threshold=30.0,
+):
+    """
+    Export both backbone and decoder to ONNX, then optionally run e2e test.
+
+    Args:
+        output_dir: Directory to save exported ONNX models.
+        model_id: HuggingFace model ID.
+        validate: Whether to run per-component validation during export.
+        convert_f16: Whether to convert weights to float16.
+        keep_f32: Whether to keep f32 models after f16 conversion.
+        backbone_kwargs: Extra kwargs passed to export_backbone.
+        decoder_kwargs: Extra kwargs passed to export_decoder.
+        run_e2e: Whether to run e2e inference test after export.
+        e2e_sentences: Test sentences for e2e test (None = defaults).
+        e2e_compare_baseline: Whether to compare against PyTorch baseline in e2e.
+        e2e_snr_pass_threshold: Min SNR (dB) for e2e PASS.
+
+    Returns:
+        dict with keys: 'backbone', 'decoder' (export results),
+        and 'e2e' (list of per-sentence results) if run_e2e=True.
+    """
+    shared = dict(
+        output_dir=output_dir,
+        model_id=model_id,
+        validate=validate,
+        convert_f16=convert_f16,
+        keep_f32=keep_f32,
+    )
+
+    print("=" * 60)
+    print("Exporting backbone...")
+    print("=" * 60)
+    backbone_result = export_backbone(**shared, **(backbone_kwargs or {}))
+
+    print("\n" + "=" * 60)
+    print("Exporting decoder...")
+    print("=" * 60)
+    decoder_result = export_decoder(**shared, **(decoder_kwargs or {}))
+
+    result = {
+        'backbone': backbone_result,
+        'decoder': decoder_result,
+    }
+
+    if run_e2e:
+        print("\n" + "=" * 60)
+        print("Running E2E test...")
+        print("=" * 60)
+        e2e_results = test_e2e(
+            onnx_dir=output_dir,
+            model_id=model_id,
+            test_sentences=e2e_sentences,
+            use_f16=convert_f16,
+            compare_baseline=e2e_compare_baseline,
+            snr_pass_threshold=e2e_snr_pass_threshold,
+        )
+        result['e2e'] = e2e_results
+
+    return result
+
+
+__all__ = ['export_all', 'export_backbone', 'export_decoder', 'test_e2e']

--- a/soprano/onnx_export/_utils.py
+++ b/soprano/onnx_export/_utils.py
@@ -1,0 +1,54 @@
+import numpy as np
+import onnx
+from onnx import numpy_helper
+
+DEFAULT_OUTPUT_DIR = 'onnx_models'
+
+
+def compute_snr(test, reference):
+    """Compute SNR (dB) between test and reference signals."""
+    noise_power = np.mean((test - reference) ** 2)
+    signal_power = np.mean(reference ** 2)
+    if noise_power == 0:
+        return float('inf')
+    if signal_power == 0:
+        return float('-inf')
+    return float(10 * np.log10(signal_power / noise_power))
+
+
+def convert_weights_to_f16(model):
+    """
+    Convert all f32 initializers to f16 with Cast nodes so graph computation stays f32.
+    Modifies the model in-place.
+
+    Returns:
+        (converted_count, cast_count) tuple.
+    """
+    converted = 0
+    for initializer in model.graph.initializer:
+        if initializer.data_type == onnx.TensorProto.FLOAT:
+            arr = numpy_helper.to_array(initializer).astype(np.float16)
+            initializer.CopyFrom(numpy_helper.from_array(arr, name=initializer.name))
+            converted += 1
+
+    init_names = {init.name for init in model.graph.initializer}
+    for vi in model.graph.input:
+        if vi.name in init_names and vi.type.tensor_type.elem_type == onnx.TensorProto.FLOAT:
+            vi.type.tensor_type.elem_type = onnx.TensorProto.FLOAT16
+
+    nodes_to_add = []
+    for initializer in model.graph.initializer:
+        if initializer.data_type == onnx.TensorProto.FLOAT16:
+            cast_out = initializer.name + '_f32'
+            nodes_to_add.append(onnx.helper.make_node(
+                'Cast', inputs=[initializer.name], outputs=[cast_out],
+                to=onnx.TensorProto.FLOAT,
+            ))
+            for node in model.graph.node:
+                for j, inp in enumerate(node.input):
+                    if inp == initializer.name:
+                        node.input[j] = cast_out
+    for node in nodes_to_add:
+        model.graph.node.insert(0, node)
+
+    return converted, len(nodes_to_add)

--- a/soprano/onnx_export/export_backbone.py
+++ b/soprano/onnx_export/export_backbone.py
@@ -1,0 +1,257 @@
+"""
+Export Soprano LLM backbone to ONNX with KV cache and hidden states output.
+Generates baselines, validates, converts to f16, and cleans up.
+
+Model: ekwek/Soprano-1.1-80M (Qwen3, 17 layers, 4 heads, 512 hidden dim)
+KV cache: 17 layers x 2 (key/value), each [batch, 1, seq_len, 128]
+"""
+import os
+
+import torch
+import torch.nn as nn
+import numpy as np
+import onnx
+import onnxruntime as ort
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers.cache_utils import DynamicCache
+
+from soprano._constants import MODEL_ID
+from soprano.onnx_export._utils import DEFAULT_OUTPUT_DIR, convert_weights_to_f16
+
+
+class BackboneWithHiddenStates(nn.Module):
+    """
+    Wraps the causal LM to output last_hidden_state alongside logits and KV cache.
+    """
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.config = model.config
+        self.num_layers = model.config.num_hidden_layers
+
+    def forward(self, input_ids, attention_mask, position_ids, *past_key_values_flat):
+        past_key_values = DynamicCache()
+        for i in range(self.num_layers):
+            k = past_key_values_flat[2 * i]
+            v = past_key_values_flat[2 * i + 1]
+            past_key_values.update(k, v, i)
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            output_hidden_states=True,
+        )
+
+        present_kv = []
+        cache = outputs.past_key_values
+        for i in range(self.num_layers):
+            present_kv.append(cache.layers[i].keys)
+            present_kv.append(cache.layers[i].values)
+
+        return (outputs.logits, outputs.hidden_states[-1], *present_kv)
+
+
+def make_onnx_feeds(input_ids_np, num_layers, num_kv_heads, head_dim, past_len=0):
+    """Build ONNX Runtime feed dict for backbone."""
+    seq_len = input_ids_np.shape[1]
+    feeds = {
+        'input_ids': input_ids_np.astype(np.int64),
+        'attention_mask': np.ones((1, past_len + seq_len), dtype=np.int64),
+        'position_ids': np.arange(past_len, past_len + seq_len, dtype=np.int64).reshape(1, -1),
+    }
+    for i in range(num_layers):
+        feeds[f'past_key_values.{i}.key'] = np.zeros((1, num_kv_heads, past_len, head_dim), dtype=np.float32)
+        feeds[f'past_key_values.{i}.value'] = np.zeros((1, num_kv_heads, past_len, head_dim), dtype=np.float32)
+    return feeds
+
+
+def export_backbone(
+    output_dir=DEFAULT_OUTPUT_DIR,
+    model_id=MODEL_ID,
+    test_prompt='[STOP][TEXT]Hello world.[START]',
+    validate=True,
+    convert_f16=True,
+    keep_f32=False,
+    f32_logits_threshold=0.01,
+    f32_hidden_threshold=0.01,
+    f16_logits_threshold=1.0,
+    f16_hidden_threshold=0.1,
+):
+    """
+    Export Soprano LLM backbone to ONNX with KV cache and hidden states output.
+
+    Args:
+        output_dir: Directory to save exported ONNX models.
+        model_id: HuggingFace model ID to export.
+        test_prompt: Prompt used for baseline generation and validation.
+        validate: Whether to run validation against PyTorch baselines.
+        convert_f16: Whether to convert weights to float16.
+        keep_f32: Whether to keep the f32 model after f16 conversion.
+        f32_logits_threshold: Max allowed logits error for f32 validation.
+        f32_hidden_threshold: Max allowed hidden states error for f32 validation.
+        f16_logits_threshold: Max allowed logits error for f16 validation.
+        f16_hidden_threshold: Max allowed hidden states error for f16 validation.
+
+    Returns:
+        dict with keys: 'f32_path', 'f16_path' (None if not converted),
+        and 'validation' results if validate=True.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    f32_path = os.path.join(output_dir, 'soprano_backbone_kv.onnx')
+    f16_path = os.path.join(output_dir, 'soprano_backbone_kv_f16.onnx')
+    result = {'f32_path': f32_path, 'f16_path': None, 'validation': {}}
+
+    # --- Load model and generate baselines ---
+    print("Loading model...")
+    model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.float32, device_map='cpu')
+    model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    config = model.config
+    num_layers = config.num_hidden_layers
+    num_kv_heads = getattr(config, 'num_key_value_heads', config.num_attention_heads)
+    head_dim = config.hidden_size // config.num_attention_heads
+    print(f"Config: {num_layers} layers, {num_kv_heads} KV heads, {head_dim} head_dim")
+
+    baseline_logits, baseline_hidden, baseline_input_ids = None, None, None
+    if validate:
+        print("Generating PyTorch baseline...")
+        inputs = tokenizer(test_prompt, return_tensors='pt')
+        input_ids = inputs['input_ids']
+        with torch.no_grad():
+            outputs = model(input_ids, output_hidden_states=True)
+        baseline_logits = outputs.logits[:, -1, :].numpy()
+        baseline_hidden = outputs.hidden_states[-1][:, -1, :].numpy()
+        baseline_input_ids = input_ids.numpy()
+        print(f"  Baseline logits: {baseline_logits.shape}, hidden: {baseline_hidden.shape}")
+
+    # --- Export ---
+    print("\nExporting backbone...")
+    wrapper = BackboneWithHiddenStates(model)
+    wrapper.eval()
+
+    # Use past_len > 0 so tracer captures KV cache path
+    batch, seq_len, past_len = 1, 1, 5
+    dummy_ids = torch.randint(0, config.vocab_size, (batch, seq_len))
+    dummy_mask = torch.ones(batch, past_len + seq_len, dtype=torch.long)
+    dummy_pos = torch.arange(past_len, past_len + seq_len).unsqueeze(0)
+    past_kv_flat = []
+    for _ in range(num_layers):
+        past_kv_flat.append(torch.zeros(batch, num_kv_heads, past_len, head_dim))
+        past_kv_flat.append(torch.zeros(batch, num_kv_heads, past_len, head_dim))
+
+    input_names = ['input_ids', 'attention_mask', 'position_ids']
+    output_names = ['logits', 'last_hidden_state']
+    dynamic_axes = {
+        'input_ids': {0: 'batch_size', 1: 'sequence_length'},
+        'attention_mask': {0: 'batch_size', 1: 'past_sequence_length + sequence_length'},
+        'position_ids': {0: 'batch_size', 1: 'sequence_length'},
+        'logits': {0: 'batch_size', 1: 'sequence_length'},
+        'last_hidden_state': {0: 'batch_size', 1: 'sequence_length'},
+    }
+    for i in range(num_layers):
+        input_names += [f'past_key_values.{i}.key', f'past_key_values.{i}.value']
+        output_names += [f'present.{i}.key', f'present.{i}.value']
+        dynamic_axes[f'past_key_values.{i}.key'] = {0: 'batch_size', 2: 'past_sequence_length'}
+        dynamic_axes[f'past_key_values.{i}.value'] = {0: 'batch_size', 2: 'past_sequence_length'}
+        dynamic_axes[f'present.{i}.key'] = {0: 'batch_size', 2: 'past_sequence_length + sequence_length'}
+        dynamic_axes[f'present.{i}.value'] = {0: 'batch_size', 2: 'past_sequence_length + sequence_length'}
+
+    dummy_inputs = (dummy_ids, dummy_mask, dummy_pos, *past_kv_flat)
+
+    print(f"  {len(input_names)} inputs, {len(output_names)} outputs")
+    torch.onnx.export(
+        wrapper, dummy_inputs, f32_path,
+        input_names=input_names, output_names=output_names,
+        dynamic_axes=dynamic_axes, opset_version=18, dynamo=False,
+    )
+    print(f"  f32 export: {os.path.getsize(f32_path) / 1024 / 1024:.1f} MB")
+    del model, wrapper
+
+    # --- Validate f32 ONNX ---
+    if validate:
+        print("\nValidating f32 ONNX...")
+        session = ort.InferenceSession(f32_path, providers=['CPUExecutionProvider'])
+        feeds = make_onnx_feeds(baseline_input_ids, num_layers, num_kv_heads, head_dim)
+        results = session.run(None, feeds)
+        logits_err = float(np.max(np.abs(results[0][:, -1, :] - baseline_logits)))
+        hidden_err = float(np.max(np.abs(results[1][:, -1, :] - baseline_hidden)))
+        print(f"  Logits max error: {logits_err:.6f}")
+        print(f"  Hidden max error: {hidden_err:.6f}")
+        f32_passed = logits_err < f32_logits_threshold and hidden_err < f32_hidden_threshold
+        result['validation']['f32'] = {
+            'logits_error': logits_err,
+            'hidden_error': hidden_err,
+            'passed': f32_passed,
+        }
+        print(f"  >>> {'PASS' if f32_passed else 'FAIL'}")
+        if not f32_passed:
+            raise AssertionError(
+                f"f32 ONNX validation failed! logits_err={logits_err:.6f}, hidden_err={hidden_err:.6f}"
+            )
+        del session
+
+    # --- Convert to f16 (weight-only, computation stays f32) ---
+    # NOTE: We intentionally use manual conversion + Cast nodes here instead of
+    # onnxruntime's convert_float_to_float16(keep_io_types=True), which converts
+    # all ops to f16. The backbone needs f32 computation for KV cache accuracy.
+    if convert_f16:
+        print("\nConverting to f16 (weight-only)...")
+        model = onnx.load(f32_path)
+        converted, cast_count = convert_weights_to_f16(model)
+        onnx.save(model, f16_path)
+        result['f16_path'] = f16_path
+        print(f"  Converted {converted} weights, added {cast_count} Cast nodes")
+        print(f"  f16 export: {os.path.getsize(f16_path) / 1024 / 1024:.1f} MB")
+        del model
+
+        # --- Validate f16 ONNX ---
+        if validate:
+            print("Validating f16 ONNX...")
+            opts = ort.SessionOptions()
+            opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+            session = ort.InferenceSession(f16_path, sess_options=opts, providers=['CPUExecutionProvider'])
+            feeds = make_onnx_feeds(baseline_input_ids, num_layers, num_kv_heads, head_dim)
+            results = session.run(None, feeds)
+            logits_err = float(np.max(np.abs(results[0][:, -1, :] - baseline_logits)))
+            hidden_err = float(np.max(np.abs(results[1][:, -1, :] - baseline_hidden)))
+            top5_baseline = np.argsort(baseline_logits[0])[-5:][::-1]
+            top5_f16 = np.argsort(results[0][0, -1, :])[-5:][::-1]
+            print(f"  Logits max error: {logits_err:.6f}")
+            print(f"  Hidden max error: {hidden_err:.6f}")
+            print(f"  Top-5 match: {set(top5_baseline) == set(top5_f16)}")
+            f16_passed = logits_err < f16_logits_threshold and hidden_err < f16_hidden_threshold
+            result['validation']['f16'] = {
+                'logits_error': logits_err,
+                'hidden_error': hidden_err,
+                'top5_match': set(top5_baseline) == set(top5_f16),
+                'passed': f16_passed,
+            }
+            print(f"  >>> {'PASS' if f16_passed else 'FAIL'}")
+            if not f16_passed:
+                raise AssertionError(
+                    f"f16 ONNX validation failed! logits_err={logits_err:.6f}, hidden_err={hidden_err:.6f}"
+                )
+
+        # --- Clean up f32 model ---
+        if not keep_f32:
+            print("\nCleaning up f32 model...")
+            os.remove(f32_path)
+            data_path = f32_path + '.data'
+            if os.path.exists(data_path):
+                os.remove(data_path)
+            result['f32_path'] = None
+
+    print("\nDone!")
+    return result
+
+
+def main():
+    export_backbone()
+
+
+if __name__ == '__main__':
+    main()

--- a/soprano/onnx_export/export_decoder.py
+++ b/soprano/onnx_export/export_decoder.py
@@ -1,0 +1,237 @@
+"""
+Export SopranoDecoder to ONNX with full ISTFT baked in.
+Uses dynamo exporter (default) + opset 18 for DFT and Col2Im support.
+Patches in-place complex ops that break dynamo tracing.
+Generates baselines, validates, converts to f16, and cleans up.
+"""
+import os
+
+import torch
+import torch.nn as nn
+import numpy as np
+import onnx
+import onnxruntime as ort
+from huggingface_hub import hf_hub_download
+from soprano.vocos.decoder import SopranoDecoder
+from soprano.vocos.spectral_ops import ISTFT
+
+from soprano._constants import MODEL_ID
+from soprano.onnx_export._utils import DEFAULT_OUTPUT_DIR, compute_snr, convert_weights_to_f16
+
+
+class PatchedISTFT(nn.Module):
+    """
+    ONNX-exportable ISTFT using explicit F.fold (maps to Col2Im at opset 18).
+    Avoids:
+    - torch.istft (decomposes to ScatterND, causes type errors)
+    - In-place complex mutation (breaks dynamo tracing)
+    Works for both "center" and "same" padding modes.
+    """
+    def __init__(self, original_istft: ISTFT):
+        super().__init__()
+        self.n_fft = original_istft.n_fft
+        self.hop_length = original_istft.hop_length
+        self.win_length = original_istft.win_length
+        self.padding = original_istft.padding
+        self.register_buffer("window", original_istft.window.clone())
+
+    def forward(self, spec: torch.Tensor) -> torch.Tensor:
+        # Zero first/last freq bins via masking (no in-place mutation)
+        N = spec.shape[1]
+        mask = torch.ones(N, device=spec.device, dtype=torch.float32)
+        mask[0] = 0.0
+        mask[-1] = 0.0
+        spec = spec * mask[None, :, None]
+
+        B, N, T = spec.shape
+
+        # Construct full spectrum from half-spectrum using conjugate symmetry,
+        # then use ifft (not irfft). This avoids ONNX DFT's invalid
+        # onesided=1 + inverse=1 combination.
+        spec_flip = torch.flip(spec[:, 1:-1, :], dims=[1])
+        spec_full = torch.cat([spec, spec_flip.conj()], dim=1)
+        ifft = torch.fft.ifft(spec_full, dim=1, norm="backward").real
+        ifft = ifft * self.window[None, :, None]
+
+        # Overlap-add via F.fold (maps to Col2Im in ONNX opset 18)
+        output_size = (T - 1) * self.hop_length + self.win_length
+        y = torch.nn.functional.fold(
+            ifft, output_size=(1, output_size),
+            kernel_size=(1, self.win_length), stride=(1, self.hop_length),
+        )[:, 0, 0, :]
+
+        # Window envelope normalization
+        window_sq = self.window.square().expand(1, T, -1).transpose(1, 2)
+        window_envelope = torch.nn.functional.fold(
+            window_sq, output_size=(1, output_size),
+            kernel_size=(1, self.win_length), stride=(1, self.hop_length),
+        ).squeeze()
+        y = y / window_envelope.clamp(min=1e-11)
+
+        # Trim based on padding mode
+        if self.padding == "center":
+            pad = self.n_fft // 2
+            y = y[:, pad:-pad]
+        elif self.padding == "same":
+            pad = (self.win_length - self.hop_length) // 2
+            y = y[:, pad:-pad]
+
+        return y
+
+
+def load_decoder(model_id=MODEL_ID):
+    """Load original unpatched decoder."""
+    decoder = SopranoDecoder()
+    decoder_path = hf_hub_download(repo_id=model_id, filename='decoder.pth')
+    decoder.load_state_dict(torch.load(decoder_path, map_location='cpu'))
+    decoder.eval()
+    return decoder
+
+
+def load_and_patch_decoder(model_id=MODEL_ID):
+    """Load decoder and patch ISTFT for ONNX export."""
+    decoder = load_decoder(model_id=model_id)
+    decoder.head.istft = PatchedISTFT(decoder.head.istft)
+    return decoder
+
+
+def export_decoder(
+    output_dir=DEFAULT_OUTPUT_DIR,
+    model_id=MODEL_ID,
+    test_seq_lengths=(64, 42, 24),
+    validate=True,
+    convert_f16=True,
+    keep_f32=False,
+    f32_snr_threshold=40.0,
+    f16_snr_threshold=30.0,
+    patch_threshold=1e-4,
+):
+    """
+    Export SopranoDecoder to ONNX with full ISTFT baked in.
+
+    Args:
+        output_dir: Directory to save exported ONNX models.
+        model_id: HuggingFace model ID to download decoder weights from.
+        test_seq_lengths: Sequence lengths for test inputs used in validation.
+        validate: Whether to run validation against PyTorch baselines.
+        convert_f16: Whether to convert to float16.
+        keep_f32: Whether to keep the f32 model after f16 conversion.
+        f32_snr_threshold: Min SNR (dB) for f32 validation to pass.
+        f16_snr_threshold: Min SNR (dB) for f16 validation to pass.
+        patch_threshold: Max allowed diff between patched and original decoder.
+
+    Returns:
+        dict with keys: 'f32_path', 'f16_path' (None if not converted),
+        and 'validation' results if validate=True.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    f32_path = os.path.join(output_dir, 'soprano_decoder.onnx')
+    f16_path = os.path.join(output_dir, 'soprano_decoder_f16.onnx')
+    result = {'f32_path': f32_path, 'f16_path': None, 'validation': {}}
+
+    test_inputs = [torch.randn(1, 512, s) for s in test_seq_lengths]
+    baselines = []
+
+    if validate:
+        # --- Generate baselines from original decoder ---
+        print("Generating PyTorch baselines...")
+        original = load_decoder(model_id=model_id)
+        for inp in test_inputs:
+            with torch.no_grad():
+                baselines.append(original(inp).numpy())
+        del original
+
+    # --- Load and validate patched decoder ---
+    print("Loading and patching decoder...")
+    decoder = load_and_patch_decoder(model_id=model_id)
+
+    if validate:
+        print("Validating patch vs original...")
+        for idx, inp in enumerate(test_inputs):
+            with torch.no_grad():
+                patched_audio = decoder(inp).numpy()
+            diff = np.abs(patched_audio - baselines[idx]).max()
+            print(f"  Input seq_len={inp.shape[2]}: max_diff={diff:.8f}")
+            if diff >= patch_threshold:
+                raise AssertionError(f"Patch diverged! max_diff={diff}")
+
+    # --- Export to ONNX ---
+    print("\nExporting with dynamo exporter, opset 18...")
+    dummy = torch.randn(1, 512, 30)
+    torch.onnx.export(
+        decoder, dummy, f32_path,
+        input_names=["hidden_states"],
+        output_names=["audio"],
+        dynamic_axes={"hidden_states": {2: "seq_len"}, "audio": {1: "audio_len"}},
+        opset_version=18,
+    )
+    print(f"  f32 export: {os.path.getsize(f32_path) / 1024 / 1024:.1f} MB")
+
+    # --- Validate f32 ONNX ---
+    if validate:
+        print("\nValidating f32 ONNX...")
+        session = ort.InferenceSession(f32_path, providers=['CPUExecutionProvider'])
+        f32_results = []
+        for idx, inp in enumerate(test_inputs):
+            inp_np = inp.numpy()
+            audio_onnx = session.run(None, {'hidden_states': inp_np})[0]
+            baseline = baselines[idx]
+            min_len = min(audio_onnx.shape[1], baseline.shape[1])
+            snr = compute_snr(audio_onnx[0, :min_len], baseline[0, :min_len])
+            print(f"  seq_len={test_inputs[idx].shape[2]}: SNR={snr:.1f} dB")
+            f32_results.append({'seq_len': inp.shape[2], 'snr': snr})
+            if snr < f32_snr_threshold:
+                raise AssertionError(f"f32 ONNX quality too low: SNR={snr:.1f}")
+        result['validation']['f32'] = f32_results
+        del session
+
+    # --- Convert to f16 (weight-only, computation stays f32) ---
+    if convert_f16:
+        print("\nConverting to f16 (weight-only)...")
+        model = onnx.load(f32_path)
+        converted, cast_count = convert_weights_to_f16(model)
+        onnx.save(model, f16_path)
+        result['f16_path'] = f16_path
+        print(f"  Converted {converted} weights, added {cast_count} Cast nodes")
+        print(f"  f16 export: {os.path.getsize(f16_path) / 1024 / 1024:.1f} MB")
+        del model
+
+        # --- Validate f16 ONNX ---
+        if validate:
+            print("Validating f16 ONNX...")
+            opts = ort.SessionOptions()
+            opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+            session = ort.InferenceSession(f16_path, sess_options=opts, providers=['CPUExecutionProvider'])
+            f16_results = []
+            for idx, inp in enumerate(test_inputs):
+                inp_np = inp.numpy()
+                audio_onnx = session.run(None, {'hidden_states': inp_np})[0]
+                baseline = baselines[idx]
+                min_len = min(audio_onnx.shape[1], baseline.shape[1])
+                snr = compute_snr(audio_onnx[0, :min_len], baseline[0, :min_len])
+                print(f"  seq_len={test_inputs[idx].shape[2]}: SNR={snr:.1f} dB")
+                f16_results.append({'seq_len': inp.shape[2], 'snr': snr})
+                if snr < f16_snr_threshold:
+                    raise AssertionError(f"f16 ONNX quality too low: SNR={snr:.1f}")
+            result['validation']['f16'] = f16_results
+
+        # --- Clean up f32 model ---
+        if not keep_f32:
+            print("\nCleaning up f32 model...")
+            os.remove(f32_path)
+            data_path = f32_path + '.data'
+            if os.path.exists(data_path):
+                os.remove(data_path)
+            result['f32_path'] = None
+
+    print("\nDone!")
+
+    return result
+
+
+def main():
+    export_decoder()
+
+
+if __name__ == '__main__':
+    main()

--- a/soprano/onnx_export/onnx_e2e_inference.py
+++ b/soprano/onnx_export/onnx_e2e_inference.py
@@ -1,0 +1,330 @@
+"""
+End-to-end ONNX inference for Soprano TTS.
+Runs backbone (autoregressive with KV cache) + decoder (hidden states -> audio)
+entirely via ONNX Runtime. Generates PyTorch baselines on the fly for comparison.
+"""
+import os
+import time
+
+import numpy as np
+import onnxruntime as ort
+from transformers import AutoTokenizer, AutoConfig
+
+from soprano._constants import MODEL_ID
+from soprano.onnx_export._utils import DEFAULT_OUTPUT_DIR, compute_snr
+
+SAMPLE_RATE = 32000
+MAX_NEW_TOKENS = 512
+
+TEST_SENTENCES = [
+    "Hello world, this is a test of the soprano text to speech system.",
+    "The quick brown fox jumps over the lazy dog.",
+    "Testing one two three.",
+]
+
+
+def get_model_config(model_id=MODEL_ID):
+    """Read architecture constants from model config instead of hardcoding."""
+    config = AutoConfig.from_pretrained(model_id)
+    return {
+        'num_layers': config.num_hidden_layers,
+        'num_kv_heads': getattr(config, 'num_key_value_heads', config.num_attention_heads),
+        'head_dim': config.hidden_size // config.num_attention_heads,
+        'eos_token_id': config.eos_token_id,
+    }
+
+
+def load_pytorch_models(model_id=MODEL_ID):
+    """Load PyTorch backbone and decoder once for baseline generation."""
+    import torch
+    from transformers import AutoModelForCausalLM
+    from huggingface_hub import hf_hub_download
+    from soprano.vocos.decoder import SopranoDecoder
+
+    model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.float32, device_map='cpu')
+    model.eval()
+
+    decoder = SopranoDecoder()
+    decoder_path = hf_hub_download(repo_id=model_id, filename='decoder.pth')
+    decoder.load_state_dict(torch.load(decoder_path, map_location='cpu'))
+    decoder.eval()
+
+    return model, decoder
+
+
+def generate_pytorch_baseline(text, tokenizer, model, decoder, max_new_tokens=MAX_NEW_TOKENS):
+    """Generate baseline audio using PyTorch (greedy decoding)."""
+    import torch
+
+    prompt = f'[STOP][TEXT]{text}[START]'
+    inputs = tokenizer(prompt, return_tensors='pt')
+
+    with torch.no_grad():
+        gen_outputs = model.generate(
+            input_ids=inputs['input_ids'],
+            attention_mask=inputs['attention_mask'],
+            max_new_tokens=max_new_tokens,
+            do_sample=False,
+            pad_token_id=tokenizer.pad_token_id,
+            return_dict_in_generate=True,
+            output_hidden_states=True,
+        )
+
+    eos_token_id = model.config.eos_token_id
+    seq = gen_outputs.sequences[0]
+    hidden_states = []
+    num_output_tokens = len(gen_outputs.hidden_states)
+    for j in range(num_output_tokens):
+        token = seq[j + seq.size(0) - num_output_tokens]
+        if token != eos_token_id:
+            hidden_states.append(gen_outputs.hidden_states[j][-1][0, -1, :])
+
+    hs = torch.stack(hidden_states)
+    decoder_input = hs.unsqueeze(0).transpose(1, 2).float()
+    with torch.no_grad():
+        audio = decoder(decoder_input)
+
+    return audio[0].numpy(), hs.numpy(), len(hidden_states)
+
+
+def load_sessions(use_f16=True, onnx_dir=DEFAULT_OUTPUT_DIR):
+    """Load backbone and decoder ONNX sessions."""
+    opts = ort.SessionOptions()
+    opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+
+    suffix = '_f16' if use_f16 else ''
+    backbone_path = os.path.join(onnx_dir, f'soprano_backbone_kv{suffix}.onnx')
+    decoder_path = os.path.join(onnx_dir, f'soprano_decoder{suffix}.onnx')
+
+    if not os.path.exists(backbone_path) or not os.path.exists(decoder_path):
+        print("ONNX models not found, exporting first...")
+        from soprano.onnx_export import export_all
+        export_all(output_dir=onnx_dir, convert_f16=use_f16, run_e2e=False)
+
+    print(f"Loading backbone: {os.path.basename(backbone_path)}")
+    backbone = ort.InferenceSession(backbone_path, sess_options=opts, providers=['CPUExecutionProvider'])
+
+    print(f"Loading decoder: {os.path.basename(decoder_path)}")
+    decoder = ort.InferenceSession(decoder_path, providers=['CPUExecutionProvider'])
+
+    return backbone, decoder
+
+
+def run_backbone_autoregressive(backbone, input_ids, model_cfg, max_new_tokens=MAX_NEW_TOKENS):
+    """
+    Run autoregressive generation with the backbone ONNX model.
+    Uses greedy decoding for deterministic comparison.
+    """
+    num_layers = model_cfg['num_layers']
+    num_kv_heads = model_cfg['num_kv_heads']
+    head_dim = model_cfg['head_dim']
+    eos_token_id = model_cfg['eos_token_id']
+
+    seq_len = input_ids.shape[1]
+    generated_ids = list(input_ids[0])
+    hidden_states = []
+
+    kv_cache = {}
+    for i in range(num_layers):
+        kv_cache[f'past_key_values.{i}.key'] = np.zeros((1, num_kv_heads, 0, head_dim), dtype=np.float32)
+        kv_cache[f'past_key_values.{i}.value'] = np.zeros((1, num_kv_heads, 0, head_dim), dtype=np.float32)
+
+    # Prefill
+    feeds = {
+        'input_ids': input_ids.astype(np.int64),
+        'attention_mask': np.ones((1, seq_len), dtype=np.int64),
+        'position_ids': np.arange(seq_len, dtype=np.int64).reshape(1, -1),
+        **kv_cache,
+    }
+    results = backbone.run(None, feeds)
+    logits = results[0]
+    last_hidden = results[1]
+    for i in range(num_layers):
+        kv_cache[f'past_key_values.{i}.key'] = results[2 + 2 * i]
+        kv_cache[f'past_key_values.{i}.value'] = results[2 + 2 * i + 1]
+
+    next_token = int(np.argmax(logits[0, -1, :]))
+
+    # Autoregressive loop
+    for step in range(max_new_tokens):
+        if next_token == eos_token_id:
+            break
+
+        hidden_states.append(last_hidden[0, -1, :])
+        generated_ids.append(next_token)
+
+        past_len = kv_cache[f'past_key_values.0.key'].shape[2]
+        feeds = {
+            'input_ids': np.array([[next_token]], dtype=np.int64),
+            'attention_mask': np.ones((1, past_len + 1), dtype=np.int64),
+            'position_ids': np.array([[past_len]], dtype=np.int64),
+            **kv_cache,
+        }
+        results = backbone.run(None, feeds)
+        logits = results[0]
+        last_hidden = results[1]
+        for i in range(num_layers):
+            kv_cache[f'past_key_values.{i}.key'] = results[2 + 2 * i]
+            kv_cache[f'past_key_values.{i}.value'] = results[2 + 2 * i + 1]
+
+        next_token = int(np.argmax(logits[0, -1, :]))
+
+    return hidden_states, generated_ids[seq_len:]
+
+
+def run_decoder(decoder, hidden_states):
+    """Run decoder: hidden states -> audio."""
+    hs = np.stack(hidden_states, axis=0)
+    decoder_input = hs[np.newaxis].transpose(0, 2, 1).astype(np.float32)
+    return decoder.run(None, {'hidden_states': decoder_input})[0].flatten()
+
+
+def compute_metrics(audio_onnx, audio_baseline):
+    """Compute SNR and max error."""
+    min_len = min(len(audio_onnx), len(audio_baseline))
+    a, b = audio_onnx[:min_len], audio_baseline[:min_len]
+    max_err = float(np.max(np.abs(a - b)))
+    snr = compute_snr(a, b)
+    return snr, max_err
+
+
+def test_e2e(
+    onnx_dir=DEFAULT_OUTPUT_DIR,
+    model_id=MODEL_ID,
+    test_sentences=None,
+    use_f16=True,
+    max_new_tokens=MAX_NEW_TOKENS,
+    compare_baseline=True,
+    snr_pass_threshold=30.0,
+    snr_marginal_threshold=20.0,
+    save_audio=None,
+):
+    """
+    Run end-to-end ONNX inference test for Soprano TTS.
+
+    Args:
+        onnx_dir: Directory containing exported ONNX models.
+        model_id: HuggingFace model ID for tokenizer and PyTorch baseline.
+        test_sentences: List of sentences to test. Defaults to built-in set.
+        use_f16: Whether to use f16 ONNX models.
+        max_new_tokens: Max tokens for autoregressive generation.
+        compare_baseline: Whether to generate PyTorch baselines for comparison.
+        snr_pass_threshold: Min SNR (dB) to consider a sentence PASS.
+        snr_marginal_threshold: Min SNR (dB) to consider MARGINAL (below = FAIL).
+        save_audio: Directory to save generated .wav files. None to skip.
+
+    Returns:
+        list of dicts, one per sentence, with keys: 'text', 'n_tokens',
+        'audio_duration', 'backbone_time', 'decoder_time', 'rtf',
+        and optionally 'snr', 'max_err', 'hs_snr', 'status'.
+    """
+    if test_sentences is None:
+        test_sentences = TEST_SENTENCES
+
+    model_cfg = get_model_config(model_id)
+    backbone, decoder = load_sessions(use_f16=use_f16, onnx_dir=onnx_dir)
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    print(f"\n{'='*60}")
+    print(f"E2E ONNX Inference ({'f16' if use_f16 else 'f32'}) {'vs PyTorch Baseline' if compare_baseline else ''}")
+    print(f"{'='*60}")
+
+    if save_audio:
+        from scipy.io import wavfile as _wavfile
+        os.makedirs(save_audio, exist_ok=True)
+
+    baselines = {}
+    if compare_baseline:
+        print("\nGenerating PyTorch baselines...")
+        pt_model, pt_decoder = load_pytorch_models(model_id)
+        for i, text in enumerate(test_sentences):
+            print(f"  Sentence {i}: \"{text[:40]}...\"")
+            audio, hs, n_tokens = generate_pytorch_baseline(
+                text, tokenizer, pt_model, pt_decoder, max_new_tokens=max_new_tokens,
+            )
+            baselines[i] = {'audio': audio, 'hidden_states': hs, 'n_tokens': n_tokens}
+            print(f"    {n_tokens} tokens, {len(audio)} samples")
+            if save_audio:
+                wav_path = os.path.join(save_audio, f'sentence_{i}_pytorch.wav')
+                audio_int16 = np.clip(audio * 32767, -32768, 32767).astype(np.int16)
+                _wavfile.write(wav_path, SAMPLE_RATE, audio_int16)
+                print(f"    Saved: {wav_path}")
+        del pt_model, pt_decoder
+
+    results = []
+    for i, text in enumerate(test_sentences):
+        print(f"\n--- Sentence {i}: \"{text[:50]}\" ---")
+
+        prompt = f'[STOP][TEXT]{text}[START]'
+        inputs = tokenizer(prompt, return_tensors='np')
+        input_ids = inputs['input_ids'].astype(np.int64)
+
+        t0 = time.time()
+        hidden_states, gen_tokens = run_backbone_autoregressive(
+            backbone, input_ids, model_cfg, max_new_tokens=max_new_tokens,
+        )
+        backbone_time = time.time() - t0
+
+        if len(hidden_states) == 0:
+            print("  WARNING: No hidden states generated!")
+            results.append({'text': text, 'n_tokens': 0, 'status': 'NO_OUTPUT'})
+            continue
+
+        t0 = time.time()
+        audio_onnx = run_decoder(decoder, hidden_states)
+        decoder_time = time.time() - t0
+
+        total_time = backbone_time + decoder_time
+        audio_dur = len(audio_onnx) / SAMPLE_RATE
+        rtf = audio_dur / total_time
+
+        if save_audio:
+            wav_path = os.path.join(save_audio, f'sentence_{i}_onnx.wav')
+            audio_int16 = np.clip(audio_onnx * 32767, -32768, 32767).astype(np.int16)
+            _wavfile.write(wav_path, SAMPLE_RATE, audio_int16)
+            print(f"  Saved: {wav_path}")
+
+        print(f"  Tokens: {len(gen_tokens)} ({backbone_time:.2f}s, {len(gen_tokens)/backbone_time:.1f} tok/s)")
+        print(f"  Audio: {audio_dur:.2f}s, decoder: {decoder_time:.3f}s, RTF: {rtf:.2f}x")
+
+        entry = {
+            'text': text,
+            'n_tokens': len(gen_tokens),
+            'audio_duration': audio_dur,
+            'backbone_time': backbone_time,
+            'decoder_time': decoder_time,
+            'rtf': rtf,
+        }
+
+        if compare_baseline and i in baselines:
+            bl = baselines[i]
+            snr, max_err = compute_metrics(audio_onnx, bl['audio'])
+            hs_onnx = np.stack(hidden_states, axis=0)
+            hs_bl = bl['hidden_states']
+            min_t = min(len(hs_onnx), len(hs_bl))
+            hs_snr = compute_snr(hs_onnx[:min_t], hs_bl[:min_t])
+
+            if snr > snr_pass_threshold:
+                status = 'PASS'
+            elif snr > snr_marginal_threshold:
+                status = 'MARGINAL'
+            else:
+                status = 'FAIL'
+
+            print(f"  vs PyTorch: SNR={snr:.1f} dB, max_err={max_err:.4f}")
+            print(f"  Hidden states: tokens={len(hs_onnx)} vs {len(hs_bl)}, SNR={hs_snr:.1f} dB")
+            print(f"  >>> {status}")
+
+            entry.update({'snr': snr, 'max_err': max_err, 'hs_snr': hs_snr, 'status': status})
+
+        results.append(entry)
+
+    return results
+
+
+def main():
+    test_e2e()
+
+
+if __name__ == '__main__':
+    main()

--- a/soprano/tts.py
+++ b/soprano/tts.py
@@ -2,6 +2,7 @@ from .vocos.decoder import SopranoDecoder
 from .utils.text_normalizer import clean_text
 from .utils.text_splitter import split_and_recombine_text
 from .utils.auto_select import select_device, select_backend
+from ._constants import MODEL_ID
 import torch
 import re
 from unidecode import unidecode
@@ -47,7 +48,7 @@ class SopranoTTS:
         if model_path:
             decoder_path = os.path.join(model_path, 'decoder.pth')
         else:
-            decoder_path = hf_hub_download(repo_id='ekwek/Soprano-1.1-80M', filename='decoder.pth')
+            decoder_path = hf_hub_download(repo_id=MODEL_ID, filename='decoder.pth')
         self.decoder.load_state_dict(torch.load(decoder_path, map_location=device))
         self.decoder_batch_size=decoder_batch_size
         self.RECEPTIVE_FIELD = 4 # Decoder receptive field


### PR DESCRIPTION
## Summary
   - Add `soprano/onnx_export/` module with backbone and decoder ONNX export, end-to-end inference, and utility helpers
   - Refactor CLI from a flat argument parser into `tts`, `export`, and `test-e2e` subcommands
   - Maintain backwards compatibility: running `soprano "text"` without a subcommand still works as before
   - Extract shared `MODEL_ID` constant into `soprano/_constants.py`
   - Update backends and `tts.py` to use the shared constant
   - Update `.gitignore` and `pyproject.toml` for ONNX export dependencies

 ## Test plan
 - [x] `uv run soprano tts "Hello world"` works with the new subcommand
 - [x] `uv run soprano "Hello world"` still works (backwards compat)
 - [x] `uv run soprano export` exports ONNX models successfully
 - [x] `uv run soprano test-e2e` runs end-to-end ONNX inference